### PR TITLE
fix: pkexec can run program with root user in non-developermode

### DIFF
--- a/debian/patches/deepin_01_fix_pkexec_privilege_escalation.patch
+++ b/debian/patches/deepin_01_fix_pkexec_privilege_escalation.patch
@@ -1,0 +1,41 @@
+Index: policykit-1-deepin/src/programs/pkexec.c
+===================================================================
+--- policykit-1-deepin.orig/src/programs/pkexec.c
++++ policykit-1-deepin/src/programs/pkexec.c
+@@ -159,6 +159,7 @@ xdg_runtime_dir_is_owned_by (const char
+ 
+ static gboolean
+ open_session (const gchar *user_to_auth,
++        const gchar *pkexec_cmd_path,
+ 	      uid_t        target_uid)
+ {
+   gboolean ret;
+@@ -185,9 +186,19 @@ open_session (const gchar *user_to_auth,
+       goto out;
+     }
+ 
++  const char *cmdpath_env = g_strdup_printf("PKEXEC_CMDPATH=%s", pkexec_cmd_path);
++  rc = pam_putenv(pam_h, cmdpath_env);
++  if (rc != PAM_SUCCESS)
++    {
++      g_printerr ("pam_putenv() failed: %s\n", pam_strerror (pam_h, rc));
++      g_free(cmdpath_env);
++      goto out;
++    }
++
+   /* open a session */
+   rc = pam_open_session (pam_h,
+                          0); /* flags */
++  g_free(cmdpath_env);
+   if (rc != PAM_SUCCESS)
+     {
+       g_printerr ("pam_open_session() failed: %s\n", pam_strerror (pam_h, rc));
+@@ -1008,7 +1019,7 @@ main (int argc, char *argv[])
+    * As evident above, neither su(1) (and, for that matter, nor sudo(8)) does this.
+    */
+ #ifdef POLKIT_AUTHFW_PAM
+-  if (!open_session (pw->pw_name,
++  if (!open_session (pw->pw_name, path,
+ 		     pw->pw_uid))
+     {
+       goto out;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+deepin_01_fix_pkexec_privilege_escalation.patch


### PR DESCRIPTION
environment.