### PR TITLE
fix(patches): add upstream locale fix patch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+policykit-1 (126-2deepin2) unstable; urgency=medium
+
+  * fix(patches): add upstream locale fix patch
+
+ -- Kun Zhang <zhangkun2@uniontech.com>  Mon, 20 Apr 2026 17:37:16 +0100
+
 policykit-1 (126-2deepin1) unstable; urgency=medium
 
   * chore(debian): restore deepin patches for upstream 126-2 upgrade

--- a/debian/patches/deepin_11_fix_locale_override.patch
+++ b/debian/patches/deepin_11_fix_locale_override.patch
@@ -1,0 +1,22 @@
+Description: Fix locale override issue in privilege escalation
+ Remove the pam_env.so configuration that forces system default locale from
+ /etc/default/locale. This prevents user locale preferences from being
+ overridden during privilege escalation.
+ .
+ Previously, if the system default was English but a user had configured
+ Chinese locale, privilege-escalated programs would incorrectly display
+ in English instead of respecting the user's Chinese preference.
+Origin: https://github.com/polkit-org/polkit/commit/4eff505162591f58ada2f43803572e789b740e59
+ .
+ This patch can be removed after syncing with upstream.
+
+diff --git a/data/polkit-1.debian b/data/polkit-1.debian
+index 6f8af2a..0f95f6d 100644
+--- a/data/polkit-1.debian
++++ b/data/polkit-1.debian
+@@ -4,5 +4,4 @@
+ @include common-account
+ @include common-password
+ session       required   pam_env.so readenv=1 user_readenv=0
+-session       required   pam_env.so readenv=1 envfile=/etc/default/locale user_readenv=0
+ @include common-session-noninteractive

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -8,3 +8,4 @@ deepin_07_fix_translate_error.patch
 deepin_08_fix_helper_exit_error.patch
 deepin_09_fix_polkit_language_env.patch
 deepin_10_fix_remove_dependencies.patch
+deepin_11_fix_locale_override.patch


### PR DESCRIPTION
1. Add deepin_11_fix_locale_override.patch from upstream
2. Patch removes pam_env.so locale override in privilege escalation
3. Can be removed after syncing upstream commit 4eff505

Log: Add upstream patch for locale override issue, removable after sync

fix(patches): 添加上游语言环境修复补丁

1. 添加来自上游的 deepin_11_fix_locale_override.patch
2. 补丁移除提权时强制使用系统语言环境的配置
3. 同步上游提交 4eff505 后可删除此补丁

Origin: https://github.com/polkit-org/polkit/commit/4eff505162591f58ada2f43803572e789b740e59