### PR TITLE
fix(polkit): fix locale not restored after authentication challenge

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+policykit-1 (123-3deepin9) unstable; urgency=medium
+
+  * fix(polkit): fix locale not restored after authentication challenge
+
+ -- Kun Zhang <zhangkun2@uniontech.com>  Wed, 29 Apr 2025 11:03:38 +0800
+
 policykit-1 (123-3deepin8) unstable; urgency=medium
 
   * fix pkexec run program with root privilege in non-developermode.

--- a/debian/patches/deepin_023_fix_polkit_locale_cleanup.patch
+++ b/debian/patches/deepin_023_fix_polkit_locale_cleanup.patch
@@ -1,0 +1,77 @@
+diff --git a/src/polkitbackend/polkitbackendinteractiveauthority.c b/src/polkitbackend/polkitbackendinteractiveauthority.c
+index 0baab54..201476e 100644
+--- a/src/polkitbackend/polkitbackendinteractiveauthority.c
++++ b/src/polkitbackend/polkitbackendinteractiveauthority.c
+@@ -2065,20 +2065,35 @@ get_localized_data_for_challenge (PolkitBackendInteractiveAuthority *authority,
+   *out_localized_icon_name = NULL;
+   *out_localized_details = NULL;
+ 
+-  action_desc = polkit_backend_action_pool_get_action (priv->action_pool,
+-                                                       action_id,
+-                                                       locale);
+-  if (action_desc == NULL)
+-    goto out;
+-
+-  /* Set LANG and locale so g_dgettext() + friends work below */
++  /* Set locale and LANGUAGE BEFORE action_pool_get_action(), because the patched
++   * _localize() (02_gettext.patch) uses dgettext() which requires a non-C
++   * setlocale to honor the LANGUAGE env var.  If setlocale to the agent's
++   * locale fails, fall back to the process initial locale from LANG so that
++   * LANGUAGE can still take effect. */
+   if (setlocale (LC_ALL, locale) == NULL)
+     {
+-      g_printerr ("Invalid locale '%s'\n", locale);
++      const gchar *lang_env = g_getenv ("LANG");
++      g_warning ("setlocale('%s') failed, trying LANG='%s'", locale, lang_env ? lang_env : "(null)");
++      if (lang_env != NULL && setlocale (LC_ALL, lang_env) == NULL)
++        {
++          g_warning ("setlocale('%s') also failed, locale stays as '%s'", lang_env, setlocale (LC_ALL, NULL));
++        }
++      /* setlocale failed, glibc didn't increment _nl_msg_cat_cntr, so
++       * gettext will use stale cached catalogs.  Force a reload so that
++       * LANGUAGE env var is re-evaluated. */
++      {
++        extern int _nl_msg_cat_cntr;
++        ++_nl_msg_cat_cntr;
++      }
+     }
+-  /* if LANGUAGE have been set in /etc/default, set LANG is invalid. */
+   g_setenv ("LANGUAGE", locale, TRUE);
+ 
++  action_desc = polkit_backend_action_pool_get_action (priv->action_pool,
++                                                        action_id,
++                                                        locale);
++  if (action_desc == NULL)
++    goto out;
++
+   gettext_domain = polkit_details_lookup (details, "polkit.gettext_domain");
+   message_to_use = polkit_details_lookup (details, "polkit.message");
+   if (message_to_use != NULL)
+@@ -2106,9 +2121,24 @@ get_localized_data_for_challenge (PolkitBackendInteractiveAuthority *authority,
+       g_free (s);
+     }
+ 
+-  /* Back to C! */
+-  setlocale (LC_ALL, "C");
+-  g_setenv ("LANGUAGE", "C", TRUE);
++  /* Restore locale to the process default (from LANG), not to "C".
++   * glibc's dgettext() ignores the LANGUAGE env var when setlocale is "C",
++   * and setting LANGUAGE="" causes gettext to cache the setlocale-based
++   * translation, making subsequent LANGUAGE overrides ineffective.
++   * Restore both setlocale and LANGUAGE to the process LANG value. */
++  {
++    const gchar *restore_locale = g_getenv ("LANG");
++    if (restore_locale != NULL)
++      {
++        setlocale (LC_ALL, restore_locale);
++        g_setenv ("LANGUAGE", restore_locale, TRUE);
++      }
++    else
++      {
++        setlocale (LC_ALL, "C");
++        g_setenv ("LANGUAGE", "C", TRUE);
++      }
++  }
+ 
+  out:
+   if (message == NULL)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -17,3 +17,4 @@ deepin_020_fix_translate_error.patch
 0001-fix-pkexec-fails-with-GDBus.Error-org.freedesktop.Po.patch
 deepin_021_fix_helper_exit_error.patch
 deepin_022_fix_pkexec_privilege_escalation.patch
+deepin_023_fix_polkit_locale_cleanup.patch


### PR DESCRIPTION
1. Move setlocale() call before action_pool_get_action() to ensure locale is active when _localize() calls dgettext()
2. Add fallback to LANG env var when setlocale(agent_locale) fails
3. Force glibc catalog reload via _nl_msg_cat_cntr when setlocale fails
4. Restore locale to process LANG instead of hardcoded "C" after challenge
5. Fix LANGUAGE env var being ignored when setlocale stays in "C" mode

Log: Fix polkit locale not properly restored after authentication, causing dgettext to ignore LANGUAGE env var

fix(polkit): 修复认证弹窗后 locale 未正确恢复的问题

1. 将 setlocale() 调用移到 action_pool_get_action() 之前，确保 _localize() 调用 dgettext() 时 locale 已生效
2. 当 setlocale(agent_locale) 失败时，回退到 LANG 环境变量
3. 当 setlocale 失败时，通过 _nl_msg_cat_cntr 强制重新加载翻译目录
4. 认证结束后恢复 locale 到进程 LANG 值，而非硬编码 "C"
5. 修复 setlocale 处于 "C" 模式时 LANGUAGE 环境变量被忽略的问题

Log: 修复 polkit 认证弹窗后 locale 未正确恢复导致 dgettext 忽略 LANGUAGE 环境变量的问题
PMS: BUG-336903